### PR TITLE
fix: remove duplicate DataTable init

### DIFF
--- a/application/views/templates/footer.php
+++ b/application/views/templates/footer.php
@@ -56,16 +56,6 @@
                 language: 'th'
             });
             
-            // Initialize data tables
-            $('.data-table').DataTable({
-                "language": {
-                    "url": "//cdn.datatables.net/plug-ins/1.10.25/i18n/Thai.json"
-                },
-                "responsive": true,
-                "pageLength": 25,
-                "order": [[0, "desc"]]
-            });
-            
             // Confirm delete actions
             $('.btn-delete').on('click', function(e) {
                 e.preventDefault();

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -30,18 +30,6 @@ $(document).ready(function() {
         $(form).addClass('was-validated');
     });
     
-    // DataTable initialization
-    if ($.fn.DataTable) {
-        $('.data-table').DataTable({
-            "language": {
-                "url": "//cdn.datatables.net/plug-ins/1.10.25/i18n/Thai.json"
-            },
-            "responsive": true,
-            "pageLength": 25,
-            "order": [[0, "desc"]]
-        });
-    }
-    
     // Confirm delete
     $('.btn-delete').click(function(e) {
         e.preventDefault();


### PR DESCRIPTION
## Summary
- remove global DataTable setup from custom.js
- drop redundant DataTable initialization in footer template

## Testing
- `php -l application/views/templates/footer.php`
- `node --check assets/js/custom.js && echo "Syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_689c9a7094cc83288b47dcf3cfdd76ca