### PR TITLE
Implement annual asset survey reporting

### DIFF
--- a/application/models/Survey_model.php
+++ b/application/models/Survey_model.php
@@ -128,49 +128,25 @@ class Survey_model extends CI_Model {
     }
 
     /**
-     * ดึงสถิติการสำรวจ
+     * ดึงสถิติการสำรวจครุภัณฑ์
      */
-    public function get_survey_statistics($year = null)
+    public function get_survey_statistics($year)
     {
-        $stats = array();
-        
-        if ($year) {
-            $this->db->where('survey_year', $year);
-        }
-        
-        // จำนวนการสำรวจทั้งหมด
-        $stats['total'] = $this->db->count_all_results('annual_surveys');
-        
-        // การสำรวจตามสภาพ
-        $this->db->select('condition, COUNT(*) as count');
-        $this->db->group_by('condition');
-        $this->db->order_by('count', 'DESC');
-        if ($year) {
-            $this->db->where('survey_year', $year);
-        }
-        $query = $this->db->get('annual_surveys');
-        $stats['conditions'] = $query->result_array();
-        
-        // การสำรวจตามปี
-        $this->db->select('survey_year, COUNT(*) as count');
-        $this->db->group_by('survey_year');
-        $this->db->order_by('survey_year', 'DESC');
-        $this->db->limit(5);
-        $query = $this->db->get('annual_surveys');
-        $stats['yearly'] = $query->result_array();
-        
-        // ครุภัณฑ์ที่ยังไม่ได้สำรวจ (ถ้าระบุปี)
-        if ($year) {
-            $this->db->select('COUNT(*) as count');
-            $this->db->from('assets a');
-            $this->db->where('a.status !=', 'จำหน่ายแล้ว');
-            $this->db->where('a.asset_id NOT IN (SELECT asset_id FROM annual_surveys WHERE survey_year = ' . $year . ')', null, false);
-            $query = $this->db->get();
-            $result = $query->row_array();
-            $stats['not_surveyed'] = $result['count'];
-        }
-        
-        return $stats;
+        // คำนวณจำนวนครุภัณฑ์ทั้งหมด (ไม่นับที่จำหน่ายแล้ว)
+        $this->db->where('status !=', 'จำหน่ายแล้ว');
+        $total_assets = $this->db->count_all_results('assets');
+
+        // จำนวนครุภัณฑ์ที่มีการสำรวจในปีที่ระบุ
+        $this->db->where('survey_year', $year);
+        $surveyed = $this->db->count_all_results('annual_surveys');
+
+        $not_surveyed = $total_assets - $surveyed;
+
+        return array(
+            'total_assets' => $total_assets,
+            'surveyed' => $surveyed,
+            'not_surveyed' => $not_surveyed
+        );
     }
 
     /**

--- a/application/views/reports/annual_survey.php
+++ b/application/views/reports/annual_survey.php
@@ -170,6 +170,17 @@
 </div>
 <?php endif; ?>
 
+<?php if (!empty($survey_stats)): ?>
+<div class="card mb-4">
+    <div class="card-header">
+        <h6 class="m-0 font-weight-bold text-primary">กราฟสถานะการสำรวจ</h6>
+    </div>
+    <div class="card-body">
+        <canvas id="surveyChart"></canvas>
+    </div>
+</div>
+<?php endif; ?>
+
 <!-- Assets Table -->
 <div class="card">
     <div class="card-header">
@@ -286,6 +297,7 @@
     </div>
 </div>
 
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script>
 $(document).ready(function() {
     // Initialize DataTable
@@ -374,6 +386,26 @@ $(document).ready(function() {
     $('#year, #location, #category, #status').on('change', function() {
         $(this).closest('form').submit();
     });
+
+    // Survey status chart
+    var ctx = document.getElementById('surveyChart');
+    if (ctx) {
+        new Chart(ctx, {
+            type: 'doughnut',
+            data: {
+                labels: ['สำรวจแล้ว', 'ยังไม่สำรวจ'],
+                datasets: [{
+                    data: [<?php echo $survey_stats['surveyed']; ?>, <?php echo $survey_stats['not_surveyed']; ?>],
+                    backgroundColor: ['#1cc88a', '#f6c23e']
+                }]
+            },
+            options: {
+                plugins: {
+                    legend: { position: 'bottom' }
+                }
+            }
+        });
+    }
 });
 </script>
 

--- a/application/views/reports/print_survey.php
+++ b/application/views/reports/print_survey.php
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="th">
+<head>
+    <meta charset="utf-8">
+    <title><?php echo $page_title; ?></title>
+    <link rel="stylesheet" href="<?php echo base_url('assets/css/bootstrap.min.css'); ?>">
+    <style>
+        body { font-size: 14px; }
+        .table th, .table td { font-size: 12px; }
+        @media print {
+            .no-print { display: none; }
+        }
+    </style>
+</head>
+<body onload="window.print()">
+<div class="container mt-4">
+    <h2 class="text-center mb-4"><?php echo $page_title; ?></h2>
+    <?php if (!empty($survey_stats)): ?>
+    <p class="text-right">
+        ครุภัณฑ์ทั้งหมด <?php echo number_format($survey_stats['total_assets']); ?> รายการ,
+        สำรวจแล้ว <?php echo number_format($survey_stats['surveyed']); ?> รายการ,
+        ยังไม่สำรวจ <?php echo number_format($survey_stats['not_surveyed']); ?> รายการ
+    </p>
+    <?php endif; ?>
+    <table class="table table-bordered">
+        <thead>
+            <tr>
+                <th>รหัส</th>
+                <th>ชื่อครุภัณฑ์</th>
+                <th>ประเภท</th>
+                <th>หมายเลขซีเรียล</th>
+                <th>สถานที่</th>
+                <th>ผู้รับผิดชอบ</th>
+                <th>ราคาทุน</th>
+                <th>ค่าเสื่อมสะสม</th>
+                <th>มูลค่าตามบัญชี</th>
+                <th>สถานะการสำรวจ</th>
+            </tr>
+        </thead>
+        <tbody>
+        <?php if (!empty($assets)): foreach ($assets as $asset): ?>
+            <tr>
+                <td><?php echo htmlspecialchars($asset['asset_code']); ?></td>
+                <td><?php echo htmlspecialchars($asset['asset_name']); ?></td>
+                <td><?php echo htmlspecialchars($asset['category']); ?></td>
+                <td><?php echo htmlspecialchars($asset['serial_number'] ?: '-'); ?></td>
+                <td><?php echo htmlspecialchars($asset['current_location']); ?></td>
+                <td><?php echo htmlspecialchars($asset['responsible_person']); ?></td>
+                <td class="text-right"><?php echo number_format($asset['purchase_price'], 2); ?></td>
+                <td class="text-right"><?php echo number_format($asset['accumulated_depreciation'], 2); ?></td>
+                <td class="text-right"><?php echo number_format($asset['book_value'], 2); ?></td>
+                <td><?php echo $asset['survey_status']; ?></td>
+            </tr>
+        <?php endforeach; endif; ?>
+        </tbody>
+    </table>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- support querying and summarizing assets for annual surveys
- show survey statistics with a Chart.js graph and CSV export
- add printable annual survey report view

## Testing
- `php -l application/models/Asset_model.php`
- `php -l application/models/Survey_model.php`
- `php -l application/views/reports/annual_survey.php`
- `php -l application/views/reports/print_survey.php`


------
https://chatgpt.com/codex/tasks/task_e_689c9d839b6c8328a9c8d4771170de25