### PR TITLE
Add repair status count method for reports

### DIFF
--- a/application/models/Repair_model.php
+++ b/application/models/Repair_model.php
@@ -251,6 +251,15 @@ class Repair_model extends CI_Model {
     }
 
     /**
+     * นับจำนวนการซ่อมแซมตามสถานะ
+     */
+    public function count_repairs_by_status($status)
+    {
+        $this->db->where('status', $status);
+        return $this->db->count_all_results('repairs');
+    }
+
+    /**
      * ดึงข้อมูลการซ่อมแซมล่าสุด
      */
     public function get_recent_repairs($limit = 10)


### PR DESCRIPTION
## Summary
- add `count_repairs_by_status` method in `Repair_model`
- ensures reports can summarize repair counts without fatal errors

## Testing
- `php -l application/models/Repair_model.php`
- `php -l application/controllers/Reports.php`


------
https://chatgpt.com/codex/tasks/task_e_689c9f956d4083289d0aed1102595922