### PR TITLE
Add survey page with save capability

### DIFF
--- a/application/controllers/Surveys.php
+++ b/application/controllers/Surveys.php
@@ -5,20 +5,59 @@ class Surveys extends CI_Controller {
     public function __construct()
     {
         parent::__construct();
-        $this->load->helper('url');
-        $this->load->library('session');
+        $this->load->model('Asset_model');
+        $this->load->model('Survey_model');
+        $this->load->helper(array('url', 'form'));
+        $this->load->library(array('session', 'form_validation'));
     }
 
     public function index()
     {
-        $data['page_title'] = 'สำรวจประจำปี - ระบบจัดการครุภัณฑ์';
+        $year = $this->input->get('year') ?: date('Y');
+        $location = $this->input->get('location');
+        $category = $this->input->get('category');
+        $status = $this->input->get('status');
+
+        $data['assets'] = $this->Asset_model->get_assets_for_survey($year, $location, $category, $status);
+        $data['survey_stats'] = $this->Survey_model->get_survey_statistics($year);
+        $data['locations'] = $this->Asset_model->get_distinct_locations();
+        $data['categories'] = $this->Asset_model->get_distinct_categories();
+
+        $data['selected_year'] = $year;
+        $data['selected_location'] = $location;
+        $data['selected_category'] = $category;
+        $data['selected_status'] = $status;
+
+        $data['page_title'] = 'สำรวจครุภัณฑ์ประจำปี ' . ($year + 543) . ' - ระบบจัดการครุภัณฑ์';
         $data['page_name'] = 'surveys';
-        $data['breadcrumbs'] = array(
-            array('title' => 'สำรวจประจำปี')
-        );
 
         $this->load->view('templates/header', $data);
         $this->load->view('surveys/index', $data);
         $this->load->view('templates/footer');
+    }
+
+    public function save()
+    {
+        $asset_id = $this->input->post('asset_id');
+        $year = $this->input->post('year');
+        $condition = $this->input->post('condition');
+        $notes = $this->input->post('notes');
+        $surveyed_by = $this->session->userdata('username') ?: 'ผู้ดูแลระบบ';
+        $survey_date = date('Y-m-d');
+
+        if ($asset_id && $year && $condition) {
+            $data = array(
+                'asset_id' => $asset_id,
+                'survey_year' => $year,
+                'condition' => $condition,
+                'notes' => $notes,
+                'surveyed_by' => $surveyed_by,
+                'survey_date' => $survey_date
+            );
+            $this->Survey_model->insert_survey($data);
+            $this->session->set_flashdata('success', 'บันทึกการสำรวจเรียบร้อยแล้ว');
+        }
+
+        redirect('surveys?year=' . $year);
     }
 }

--- a/application/views/surveys/index.php
+++ b/application/views/surveys/index.php
@@ -1,20 +1,506 @@
 <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
     <h1 class="h2">
-        <i class="fas fa-clipboard-check"></i>
-        สำรวจประจำปี
+        <i class="fas fa-search"></i>
+        สำรวจครุภัณฑ์ประจำปี <?php echo ($selected_year + 543); ?>
     </h1>
     <div class="btn-toolbar mb-2 mb-md-0">
         <div class="btn-group mr-2">
-            <button type="button" class="btn btn-sm btn-outline-secondary" onclick="location.reload()">
+            <button type="button" class="btn btn-secondary" onclick="location.reload()">
                 <i class="fas fa-sync-alt"></i> รีเฟรช
             </button>
+            <a href="<?php echo base_url('dashboard'); ?>" class="btn btn-outline-secondary">
+                <i class="fas fa-arrow-left"></i> กลับ
+            </a>
         </div>
     </div>
 </div>
 
-<div class="card">
-    <div class="card-body text-center text-muted">
-        <i class="fas fa-clipboard-list fa-3x mb-3"></i>
-        <p>หน้านี้อยู่ระหว่างการพัฒนา</p>
+<?php if ($this->session->flashdata('success')): ?>
+<div class="alert alert-success alert-dismissible fade show mt-3" role="alert">
+    <?php echo $this->session->flashdata('success'); ?>
+    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+        <span aria-hidden="true">&times;</span>
+    </button>
+</div>
+<?php endif; ?>
+
+<!-- Filter Section -->
+<div class="card mb-4">
+    <div class="card-body">
+        <form method="GET" action="<?php echo base_url('surveys'); ?>">
+            <div class="row">
+                <div class="col-md-3 mb-3">
+                    <label for="year">ปีงบประมาณ</label>
+                    <select class="form-control" id="year" name="year">
+                        <?php for ($y = date('Y'); $y >= date('Y') - 10; $y--): ?>
+                            <option value="<?php echo $y; ?>" <?php echo ($selected_year == $y) ? 'selected' : ''; ?>>
+                                <?php echo ($y + 543); ?>
+                            </option>
+                        <?php endfor; ?>
+                    </select>
+                </div>
+                <div class="col-md-3 mb-3">
+                    <label for="location">สถานที่</label>
+                    <select class="form-control" id="location" name="location">
+                        <option value="">ทั้งหมด</option>
+                        <?php if (!empty($locations)): ?>
+                            <?php foreach ($locations as $loc): ?>
+                                <option value="<?php echo htmlspecialchars($loc['current_location']); ?>" 
+                                        <?php echo ($selected_location == $loc['current_location']) ? 'selected' : ''; ?>>
+                                    <?php echo htmlspecialchars($loc['current_location']); ?>
+                                </option>
+                            <?php endforeach; ?>
+                        <?php endif; ?>
+                    </select>
+                </div>
+                <div class="col-md-3 mb-3">
+                    <label for="category">ประเภท</label>
+                    <select class="form-control" id="category" name="category">
+                        <option value="">ทั้งหมด</option>
+                        <?php if (!empty($categories)): ?>
+                            <?php foreach ($categories as $cat): ?>
+                                <option value="<?php echo htmlspecialchars($cat['category']); ?>" 
+                                        <?php echo ($selected_category == $cat['category']) ? 'selected' : ''; ?>>
+                                    <?php echo htmlspecialchars($cat['category']); ?>
+                                </option>
+                            <?php endforeach; ?>
+                        <?php endif; ?>
+                    </select>
+                </div>
+                <div class="col-md-2 mb-3">
+                    <label for="status">สถานะ</label>
+                    <select class="form-control" id="status" name="status">
+                        <option value="">ทั้งหมด</option>
+                        <option value="ใช้งาน" <?php echo ($selected_status == 'ใช้งาน') ? 'selected' : ''; ?>>ใช้งาน</option>
+                        <option value="ซ่อมแซม" <?php echo ($selected_status == 'ซ่อมแซม') ? 'selected' : ''; ?>>ซ่อมแซม</option>
+                        <option value="ไม่ใช้งาน" <?php echo ($selected_status == 'ไม่ใช้งาน') ? 'selected' : ''; ?>>ไม่ใช้งาน</option>
+                    </select>
+                </div>
+                <div class="col-md-1 mb-3">
+                    <label>&nbsp;</label>
+                    <div>
+                        <button type="submit" class="btn btn-primary btn-block">
+                            <i class="fas fa-search"></i>
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </form>
     </div>
 </div>
+
+<!-- Survey Statistics -->
+<?php if (!empty($survey_stats)): ?>
+<div class="row mb-4">
+    <div class="col-md-3">
+        <div class="card border-left-primary shadow h-100 py-2">
+            <div class="card-body">
+                <div class="row no-gutters align-items-center">
+                    <div class="col mr-2">
+                        <div class="text-xs font-weight-bold text-primary text-uppercase mb-1">
+                            ครุภัณฑ์ทั้งหมด
+                        </div>
+                        <div class="h5 mb-0 font-weight-bold text-gray-800">
+                            <?php echo number_format($survey_stats['total_assets']); ?>
+                        </div>
+                    </div>
+                    <div class="col-auto">
+                        <i class="fas fa-box fa-2x text-gray-300"></i>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    
+    <div class="col-md-3">
+        <div class="card border-left-success shadow h-100 py-2">
+            <div class="card-body">
+                <div class="row no-gutters align-items-center">
+                    <div class="col mr-2">
+                        <div class="text-xs font-weight-bold text-success text-uppercase mb-1">
+                            สำรวจแล้ว
+                        </div>
+                        <div class="h5 mb-0 font-weight-bold text-gray-800">
+                            <?php echo number_format($survey_stats['surveyed']); ?>
+                        </div>
+                    </div>
+                    <div class="col-auto">
+                        <i class="fas fa-check fa-2x text-gray-300"></i>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    
+    <div class="col-md-3">
+        <div class="card border-left-warning shadow h-100 py-2">
+            <div class="card-body">
+                <div class="row no-gutters align-items-center">
+                    <div class="col mr-2">
+                        <div class="text-xs font-weight-bold text-warning text-uppercase mb-1">
+                            ยังไม่สำรวจ
+                        </div>
+                        <div class="h5 mb-0 font-weight-bold text-gray-800">
+                            <?php echo number_format($survey_stats['not_surveyed']); ?>
+                        </div>
+                    </div>
+                    <div class="col-auto">
+                        <i class="fas fa-exclamation fa-2x text-gray-300"></i>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    
+    <div class="col-md-3">
+        <div class="card border-left-info shadow h-100 py-2">
+            <div class="card-body">
+                <div class="row no-gutters align-items-center">
+                    <div class="col mr-2">
+                        <div class="text-xs font-weight-bold text-info text-uppercase mb-1">
+                            ความคืบหน้า
+                        </div>
+                        <div class="h5 mb-0 font-weight-bold text-gray-800">
+                            <?php echo number_format(($survey_stats['surveyed'] / $survey_stats['total_assets']) * 100, 1); ?>%
+                        </div>
+                    </div>
+                    <div class="col-auto">
+                        <i class="fas fa-chart-pie fa-2x text-gray-300"></i>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+<?php endif; ?>
+
+<?php if (!empty($survey_stats)): ?>
+<div class="card mb-4">
+    <div class="card-header">
+        <h6 class="m-0 font-weight-bold text-primary">กราฟสถานะการสำรวจ</h6>
+    </div>
+    <div class="card-body">
+        <canvas id="surveyChart"></canvas>
+    </div>
+</div>
+<?php endif; ?>
+
+<!-- Assets Table -->
+<div class="card">
+    <div class="card-header">
+        <h6 class="m-0 font-weight-bold text-primary">
+            รายการครุภัณฑ์สำหรับสำรวจ
+            <?php if (!empty($assets)): ?>
+                (<?php echo number_format(count($assets)); ?> รายการ)
+            <?php endif; ?>
+        </h6>
+    </div>
+    <div class="card-body">
+        <?php if (!empty($assets)): ?>
+            <div class="table-responsive">
+                <table class="table table-striped table-hover" id="surveyTable">
+                    <thead>
+                        <tr>
+                            <th>รหัส</th>
+                            <th>ชื่อครุภัณฑ์</th>
+                            <th>ประเภท</th>
+                            <th>หมายเลขซีเรียล</th>
+                            <th>สถานที่</th>
+                            <th>ผู้รับผิดชอบ</th>
+                            <th>ราคาทุน</th>
+                            <th>ค่าเสื่อมสะสม</th>
+                            <th>มูลค่าตามบัญชี</th>
+                            <th>สถานะ</th>
+                            <th>สถานะการสำรวจ</th>
+                            <th>จัดการ</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($assets as $asset): ?>
+                            <?php $book_value = $asset['purchase_price'] - $asset['accumulated_depreciation']; ?>
+                            <tr>
+                                <td>
+                                    <a href="<?php echo base_url('assets/view/' . $asset['asset_id']); ?>" 
+                                       class="text-decoration-none font-weight-bold">
+                                        <?php echo htmlspecialchars($asset['asset_code']); ?>
+                                    </a>
+                                </td>
+                                <td><?php echo htmlspecialchars($asset['asset_name']); ?></td>
+                                <td>
+                                    <span class="badge badge-secondary">
+                                        <?php echo htmlspecialchars($asset['category']); ?>
+                                    </span>
+                                </td>
+                                <td>
+                                    <small><?php echo htmlspecialchars($asset['serial_number'] ?: '-'); ?></small>
+                                </td>
+                                <td>
+                                    <small><?php echo htmlspecialchars($asset['current_location']); ?></small>
+                                </td>
+                                <td>
+                                    <small><?php echo htmlspecialchars($asset['responsible_person']); ?></small>
+                                </td>
+                                <td class="text-right">
+                                    <?php echo number_format($asset['purchase_price'], 2); ?>
+                                </td>
+                                <td class="text-right">
+                                    <span class="text-danger">
+                                        <?php echo number_format($asset['accumulated_depreciation'], 2); ?>
+                                    </span>
+                                </td>
+                                <td class="text-right">
+                                    <strong><?php echo number_format($book_value, 2); ?></strong>
+                                </td>
+                                <td>
+                                    <span class="asset-status"><?php echo $asset['status']; ?></span>
+                                </td>
+                                <td>
+                                    <span class="survey-status" data-asset-id="<?php echo $asset['asset_id']; ?>">
+                                        <?php echo isset($asset['survey_status']) ? $asset['survey_status'] : 'ยังไม่สำรวจ'; ?>
+                                    </span>
+                                </td>
+                                <td>
+                                    <?php if (empty($asset['survey_id'])): ?>
+                                        <button type="button" class="btn btn-primary btn-sm save-survey-btn"
+                                                data-asset-id="<?php echo $asset['asset_id']; ?>"
+                                                data-asset-name="<?php echo htmlspecialchars($asset['asset_name']); ?>">
+                                            บันทึก
+                                        </button>
+                                    <?php else: ?>
+                                        <span class="text-success">-</span>
+                                    <?php endif; ?>
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                    <tfoot>
+                        <tr class="table-info">
+                            <th colspan="6">รวม</th>
+                            <th class="text-right">
+                                <?php
+                                $total_cost = array_sum(array_column($assets, 'purchase_price'));
+                                echo number_format($total_cost, 2);
+                                ?>
+                            </th>
+                            <th class="text-right">
+                                <?php
+                                $total_depreciation = array_sum(array_column($assets, 'accumulated_depreciation'));
+                                echo number_format($total_depreciation, 2);
+                                ?>
+                            </th>
+                            <th class="text-right">
+                                <strong><?php echo number_format($total_cost - $total_depreciation, 2); ?></strong>
+                            </th>
+                            <th colspan="3"></th>
+                        </tr>
+                    </tfoot>
+                </table>
+            </div>
+        <?php else: ?>
+            <div class="text-center py-5">
+                <i class="fas fa-search fa-5x text-muted mb-3"></i>
+                <h5 class="text-muted">ไม่พบข้อมูลครุภัณฑ์</h5>
+                <p class="text-muted">
+                    <?php if (!empty($selected_location) || !empty($selected_category) || !empty($selected_status)): ?>
+                        ลองปรับเปลี่ยนเงื่อนไขการค้นหา หรือ
+                        <a href="<?php echo base_url('surveys?year=' . $selected_year); ?>">ดูทั้งหมด</a>
+                    <?php else: ?>
+                        ไม่มีครุภัณฑ์ในปีที่เลือก
+                    <?php endif; ?>
+                </p>
+            </div>
+        <?php endif; ?>
+    </div>
+</div>
+
+<!-- Survey Modal -->
+<div class="modal fade" id="surveyModal" tabindex="-1" role="dialog" aria-labelledby="surveyModalLabel" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <form method="post" action="<?php echo base_url('surveys/save'); ?>">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="surveyModalLabel">บันทึกการสำรวจ: <span id="assetName"></span></h5>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <input type="hidden" name="asset_id" id="modalAssetId">
+                    <input type="hidden" name="year" value="<?php echo $selected_year; ?>">
+                    <div class="form-group">
+                        <label for="condition">สภาพครุภัณฑ์</label>
+                        <select class="form-control" name="condition" id="condition" required>
+                            <option value="ดี">ดี</option>
+                            <option value="พอใช้">พอใช้</option>
+                            <option value="ชำรุด">ชำรุด</option>
+                            <option value="ไม่สามารถใช้งานได้">ไม่สามารถใช้งานได้</option>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label for="notes">บันทึกเพิ่มเติม</label>
+                        <textarea class="form-control" name="notes" id="notes" rows="3"></textarea>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">ยกเลิก</button>
+                    <button type="submit" class="btn btn-primary">บันทึก</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+$(document).ready(function() {
+    // Initialize DataTable
+    $('#surveyTable').DataTable({
+        "language": {
+            "url": "//cdn.datatables.net/plug-ins/1.10.25/i18n/Thai.json"
+        },
+        "responsive": true,
+        "pageLength": 50,
+        "order": [[0, "asc"]],
+        "columnDefs": [
+            { "orderable": false, "targets": [10, 11] }
+        ],
+        "footerCallback": function(row, data, start, end, display) {
+            // Update footer totals for visible rows only
+            var api = this.api();
+            
+            // Calculate totals for visible rows
+            var totalCost = api
+                .column(6, { page: 'current' })
+                .data()
+                .reduce(function(a, b) {
+                    return parseFloat(a) + parseFloat(b.replace(/,/g, ''));
+                }, 0);
+                
+            var totalDepreciation = api
+                .column(7, { page: 'current' })
+                .data()
+                .reduce(function(a, b) {
+                    return parseFloat(a) + parseFloat(b.replace(/,/g, ''));
+                }, 0);
+            
+            var totalBookValue = totalCost - totalDepreciation;
+            
+            // Update footer
+            $(api.column(6).footer()).html(totalCost.toLocaleString('th-TH', {minimumFractionDigits: 2}));
+            $(api.column(7).footer()).html(totalDepreciation.toLocaleString('th-TH', {minimumFractionDigits: 2}));
+            $(api.column(8).footer()).html('<strong>' + totalBookValue.toLocaleString('th-TH', {minimumFractionDigits: 2}) + '</strong>');
+        }
+    });
+    
+    // Asset status badges
+    $('.asset-status').each(function() {
+        var status = $(this).text().trim();
+        $(this).removeClass('badge-secondary badge-success badge-danger badge-warning');
+        
+        switch(status) {
+            case 'ใช้งาน':
+                $(this).addClass('badge badge-success');
+                break;
+            case 'ซ่อมแซม':
+                $(this).addClass('badge badge-warning');
+                break;
+            case 'ไม่ใช้งาน':
+                $(this).addClass('badge badge-secondary');
+                break;
+            case 'จำหน่ายแล้ว':
+                $(this).addClass('badge badge-danger');
+                break;
+            default:
+                $(this).addClass('badge badge-secondary');
+        }
+    });
+    
+    // Survey status badges
+    $('.survey-status').each(function() {
+        var status = $(this).text().trim();
+        $(this).removeClass('badge-secondary badge-success badge-warning badge-danger');
+        
+        switch(status) {
+            case 'สำรวจแล้ว':
+                $(this).addClass('badge badge-success');
+                break;
+            case 'ยังไม่สำรวจ':
+                $(this).addClass('badge badge-warning');
+                break;
+            case 'ไม่พบ':
+                $(this).addClass('badge badge-danger');
+                break;
+            default:
+                $(this).addClass('badge badge-secondary');
+        }
+    });
+    
+    // Auto-submit form on change
+    $('#year, #location, #category, #status').on('change', function() {
+        $(this).closest('form').submit();
+    });
+
+    // Open survey modal
+    $('.save-survey-btn').on('click', function() {
+        var assetId = $(this).data('asset-id');
+        var assetName = $(this).data('asset-name');
+        $('#modalAssetId').val(assetId);
+        $('#assetName').text(assetName);
+        $('#surveyModal').modal('show');
+    });
+
+    // Survey status chart
+    var ctx = document.getElementById('surveyChart');
+    if (ctx) {
+        new Chart(ctx, {
+            type: 'doughnut',
+            data: {
+                labels: ['สำรวจแล้ว', 'ยังไม่สำรวจ'],
+                datasets: [{
+                    data: [<?php echo $survey_stats['surveyed']; ?>, <?php echo $survey_stats['not_surveyed']; ?>],
+                    backgroundColor: ['#1cc88a', '#f6c23e']
+                }]
+            },
+            options: {
+                plugins: {
+                    legend: { position: 'bottom' }
+                }
+            }
+        });
+    }
+});
+</script>
+
+<style>
+.border-left-primary {
+    border-left: 0.25rem solid #4e73df !important;
+}
+
+.border-left-success {
+    border-left: 0.25rem solid #1cc88a !important;
+}
+
+.border-left-info {
+    border-left: 0.25rem solid #36b9cc !important;
+}
+
+.border-left-warning {
+    border-left: 0.25rem solid #f6c23e !important;
+}
+
+.table-responsive {
+    font-size: 0.875rem;
+}
+
+.table th {
+    border-top: none;
+    font-weight: 600;
+    background-color: #f8f9fc;
+}
+
+.table tfoot th {
+    background-color: #e3f2fd;
+    font-weight: 600;
+}
+</style>
+


### PR DESCRIPTION
## Summary
- Implement surveys page with filtering and asset listing
- Add per-asset survey save workflow with modal form

## Testing
- `php -l application/controllers/Surveys.php`
- `php -l application/views/surveys/index.php`
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689cab3025f08328930bd0f57c868796