### PR TITLE
Fix asset edit routing

### DIFF
--- a/application/config/routes.php
+++ b/application/config/routes.php
@@ -54,4 +54,5 @@ $route['404_override'] = '';
 $route['translate_uri_dashes'] = FALSE;
 
 $route['assets'] = 'assetmanager';           // GET /asset_management_system/assets  → AssetManager controller
-$route['assets/(:any)'] = 'assetmanager/$1'; // รองรับเมธ็อด /assets/create ฯลฯ
+$route['assets/(:any)'] = 'assetmanager/$1';                // รองรับเมธ็อด /assets/create ฯลฯ
+$route['assets/(:any)/(:any)'] = 'assetmanager/$1/$2';      // รองรับเมธ็อดที่มีพารามิเตอร์ เช่น /assets/edit/4


### PR DESCRIPTION
## Summary
- allow two-segment asset routes to reach AssetManager controller

## Testing
- ⚠️ `composer install --no-interaction` *(403 CONNECT tunnel failed)*
- ⚠️ `phpunit --version` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cae1bfb908328be510618311089fc