### PR TITLE
Map maintenance route to repairs add

### DIFF
--- a/application/config/routes.php
+++ b/application/config/routes.php
@@ -66,3 +66,5 @@ $route['assets/view/(:num)']   = 'assetmanager/view/$1';
 $route['assets/update/(:num)'] = 'assetmanager/update/$1';
 $route['assets/delete/(:num)'] = 'assetmanager/delete/$1';
 $route['assets/export']        = 'assetmanager/export';
+$route['assets/maintenance/(:num)'] = 'repairs/add/$1';
+$route['assetmanager/maintenance/(:num)'] = 'repairs/add/$1';

--- a/application/controllers/Repairs.php
+++ b/application/controllers/Repairs.php
@@ -71,19 +71,19 @@ class Repairs extends CI_Controller {
     /**
      * แสดงฟอร์มขออนุญาตซ่อมแซม
      */
-    public function add()
+    public function add($asset_id = null)
     {
         $data = array();
-        
+
         // ดึงรายการครุภัณฑ์ที่สามารถซ่อมแซมได้
         $data['assets'] = $this->Asset_model->get_repairable_assets();
-        
-        // ถ้ามี asset_id ใน URL ให้เลือกไว้
-        $data['selected_asset_id'] = $this->input->get('asset_id');
-        
+
+        // รองรับการระบุ asset_id ทั้งจากพารามิเตอร์และ query string
+        $data['selected_asset_id'] = $asset_id !== null ? $asset_id : $this->input->get('asset_id');
+
         $data['page_title'] = 'ขออนุญาตซ่อมแซมครุภัณฑ์ - ระบบจัดการครุภัณฑ์';
         $data['page_name'] = 'add_repair';
-        
+
         $this->load->view('templates/header', $data);
         $this->load->view('repairs/add', $data);
         $this->load->view('templates/footer');


### PR DESCRIPTION
## Summary
- Route `/assets/maintenance/{id}` and `/assetmanager/maintenance/{id}` to the repairs add page
- Allow `Repairs::add` to accept asset IDs from the path or query string

## Testing
- `php -l application/config/routes.php`
- `php -l application/controllers/Repairs.php`
- `composer install` *(fails: curl error 56 while downloading packages.json: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689d3eeabd788328b26eda04379890d4