### PR TITLE
Handle missing contact info in repair view

### DIFF
--- a/application/views/repairs/view.php
+++ b/application/views/repairs/view.php
@@ -50,7 +50,7 @@
                     </tr>
                     <tr>
                         <th>ข้อมูลติดต่อ:</th>
-                        <td><?php echo htmlspecialchars($repair['contact_info']); ?></td>
+                        <td><?php echo htmlspecialchars(isset($repair['contact_info']) ? $repair['contact_info'] : ''); ?></td>
                     </tr>
                 </table>
             </div>


### PR DESCRIPTION
## Summary
- avoid undefined index notice when contact_info is absent

## Testing
- `php -l application/views/repairs/view.php`
- `composer install --no-interaction --no-progress` *(fails: curl error 56 while downloading packages)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689d4482f98c83289bc349d598bca50a