### PR TITLE
Handle missing repair type in repair views

### DIFF
--- a/application/views/repairs/print_request.php
+++ b/application/views/repairs/print_request.php
@@ -205,7 +205,7 @@
                 <tr>
                     <td class="label">ประเภทการซ่อม</td>
                     <td class="colon">:</td>
-                    <td><?php echo htmlspecialchars($repair['repair_type']); ?></td>
+                    <td><?php echo htmlspecialchars(isset($repair['repair_type']) ? $repair['repair_type'] : ''); ?></td>
                 </tr>
                 <tr>
                     <td class="label">ระดับความสำคัญ</td>

--- a/application/views/repairs/view.php
+++ b/application/views/repairs/view.php
@@ -58,7 +58,7 @@
                 <table class="table table-borderless">
                     <tr>
                         <th width="35%">ประเภทการซ่อม:</th>
-                        <td><?php echo htmlspecialchars($repair['repair_type']); ?></td>
+                        <td><?php echo htmlspecialchars(isset($repair['repair_type']) ? $repair['repair_type'] : ''); ?></td>
                     </tr>
                     <tr>
                         <th>ความสำคัญ:</th>


### PR DESCRIPTION
## Summary
- Prevent undefined index notices when `repair_type` is absent in repair views
- Safely display repair type in printable repair request page

## Testing
- `php -l application/views/repairs/view.php`
- `php -l application/views/repairs/print_request.php`
- `php test_system.php` *(fails: Failed opening required '1core/CodeIgniter.php')*

------
https://chatgpt.com/codex/tasks/task_e_689d460e0ff88328a94b310f53cdaade