### PR TITLE
Handle missing repair priority

### DIFF
--- a/application/views/repairs/view.php
+++ b/application/views/repairs/view.php
@@ -62,7 +62,13 @@
                     </tr>
                     <tr>
                         <th>ความสำคัญ:</th>
-                        <td><span class="priority-badge"><?php echo htmlspecialchars($repair['priority']); ?></span></td>
+                        <td>
+                            <span class="priority-badge">
+                                <?php echo isset($repair['priority'])
+                                    ? htmlspecialchars($repair['priority'])
+                                    : '<span style="color: gray;">-</span>'; ?>
+                            </span>
+                        </td>
                     </tr>
                     <tr>
                         <th>สถานะ:</th>


### PR DESCRIPTION
## Summary
- Prevent undefined index notices by safely displaying repair priority in repair view

## Testing
- `php -l application/views/repairs/view.php`
- `php test_system.php` *(fails: Failed opening required '1core/CodeIgniter.php')*

------
https://chatgpt.com/codex/tasks/task_e_689d46dfb22c83289b15fb05e38a2a0d