### PR TITLE
fix undefined problem description index

### DIFF
--- a/application/views/repairs/view.php
+++ b/application/views/repairs/view.php
@@ -99,7 +99,7 @@
                 <h6>รายละเอียดปัญหา</h6>
                 <div class="card bg-light">
                     <div class="card-body">
-                        <?php echo nl2br(htmlspecialchars($repair['problem_description'])); ?>
+                        <?php echo isset($repair['problem_description']) ? nl2br(htmlspecialchars($repair['problem_description'])) : ''; ?>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- prevent undefined index notice for problem_description in repair view

## Testing
- `php -l application/views/repairs/view.php`
- `phpunit` *(fails: command not found)*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689d47e92048832898e1ed66025a7a1d