### PR TITLE
Add asset type management CRUD

### DIFF
--- a/application/config/routes.php
+++ b/application/config/routes.php
@@ -68,3 +68,7 @@ $route['assets/delete/(:num)'] = 'assetmanager/delete/$1';
 $route['assets/export']        = 'assetmanager/export';
 $route['assets/maintenance/(:num)'] = 'repairs/add/$1';
 $route['assetmanager/maintenance/(:num)'] = 'repairs/add/$1';
+$route['assettypes']               = 'assettypes/index';
+$route['assettypes/add']           = 'assettypes/add';
+$route['assettypes/edit/(:num)']   = 'assettypes/edit/$1';
+$route['assettypes/delete/(:num)'] = 'assettypes/delete/$1';

--- a/application/controllers/Assetmanager.php
+++ b/application/controllers/Assetmanager.php
@@ -89,6 +89,7 @@ class Assetmanager extends CI_Controller {
         $data = array();
         $data['page_title'] = 'เพิ่มครุภัณฑ์ใหม่ - ระบบจัดการครุภัณฑ์';
         $data['page_name'] = 'add_asset';
+        $data['asset_types'] = $this->Asset_model->get_asset_types();
         
         $this->load->view('templates/header', $data);
         $this->load->view('assetmanager/add', $data);
@@ -164,6 +165,7 @@ class Assetmanager extends CI_Controller {
         
         $data['page_title'] = 'แก้ไขครุภัณฑ์: ' . $data['asset']['asset_name'];
         $data['page_name'] = 'edit_asset';
+        $data['asset_types'] = $this->Asset_model->get_asset_types();
         
         $this->load->view('templates/header', $data);
         $this->load->view('assetmanager/edit', $data);

--- a/application/controllers/Assettypes.php
+++ b/application/controllers/Assettypes.php
@@ -1,0 +1,128 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Assettypes extends CI_Controller {
+    public function __construct()
+    {
+        parent::__construct();
+        $this->load->model('Assettype_model');
+        $this->load->helper(['url', 'form']);
+        $this->load->library(['session', 'form_validation']);
+    }
+
+    public function index()
+    {
+        $data['types'] = $this->Assettype_model->get_all_types();
+        $data['page_title'] = 'จัดการประเภทครุภัณฑ์ - ระบบจัดการครุภัณฑ์';
+        $data['page_name'] = 'assettypes';
+
+        $this->load->view('templates/header', $data);
+        $this->load->view('assettypes/index', $data);
+        $this->load->view('templates/footer');
+    }
+
+    public function add()
+    {
+        $data['page_title'] = 'เพิ่มประเภทครุภัณฑ์ - ระบบจัดการครุภัณฑ์';
+        $data['page_name'] = 'assettypes_add';
+
+        $this->load->view('templates/header', $data);
+        $this->load->view('assettypes/add', $data);
+        $this->load->view('templates/footer');
+    }
+
+    public function store()
+    {
+        $this->form_validation->set_rules('type_name', 'ชื่อประเภท', 'required|is_unique[asset_types.type_name]');
+        $this->form_validation->set_rules('description', 'คำอธิบาย', 'trim');
+
+        if ($this->form_validation->run() == FALSE) {
+            $this->add();
+            return;
+        }
+
+        $data = [
+            'type_name' => $this->input->post('type_name'),
+            'description' => $this->input->post('description')
+        ];
+
+        if ($this->Assettype_model->insert_type($data)) {
+            $this->session->set_flashdata('success', 'เพิ่มประเภทครุภัณฑ์เรียบร้อยแล้ว');
+            redirect('assettypes');
+        } else {
+            $this->session->set_flashdata('error', 'เกิดข้อผิดพลาดในการบันทึกข้อมูล');
+            $this->add();
+        }
+    }
+
+    public function edit($id)
+    {
+        $data['type'] = $this->Assettype_model->get_type_by_id($id);
+        if (!$data['type']) {
+            show_404();
+        }
+
+        $data['page_title'] = 'แก้ไขประเภทครุภัณฑ์ - ระบบจัดการครุภัณฑ์';
+        $data['page_name'] = 'assettypes_edit';
+
+        $this->load->view('templates/header', $data);
+        $this->load->view('assettypes/edit', $data);
+        $this->load->view('templates/footer');
+    }
+
+    public function update($id)
+    {
+        $type = $this->Assettype_model->get_type_by_id($id);
+        if (!$type) {
+            show_404();
+        }
+
+        $this->form_validation->set_rules('type_name', 'ชื่อประเภท', 'required|callback_unique_type['.$id.']');
+        $this->form_validation->set_rules('description', 'คำอธิบาย', 'trim');
+
+        if ($this->form_validation->run() == FALSE) {
+            $this->edit($id);
+            return;
+        }
+
+        $data = [
+            'type_name' => $this->input->post('type_name'),
+            'description' => $this->input->post('description')
+        ];
+
+        if ($this->Assettype_model->update_type($id, $data)) {
+            $this->session->set_flashdata('success', 'อัปเดตประเภทครุภัณฑ์เรียบร้อยแล้ว');
+            redirect('assettypes');
+        } else {
+            $this->session->set_flashdata('error', 'เกิดข้อผิดพลาดในการอัปเดตข้อมูล');
+            $this->edit($id);
+        }
+    }
+
+    public function delete($id)
+    {
+        $type = $this->Assettype_model->get_type_by_id($id);
+        if (!$type) {
+            show_404();
+        }
+
+        if ($this->Assettype_model->delete_type($id)) {
+            $this->session->set_flashdata('success', 'ลบประเภทครุภัณฑ์เรียบร้อยแล้ว');
+        } else {
+            $this->session->set_flashdata('error', 'เกิดข้อผิดพลาดในการลบข้อมูล');
+        }
+        redirect('assettypes');
+    }
+
+    public function unique_type($str, $id)
+    {
+        $this->db->where('type_name', $str);
+        $this->db->where('type_id !=', $id);
+        $query = $this->db->get('asset_types');
+        if ($query->num_rows() > 0) {
+            $this->form_validation->set_message('unique_type', 'ชื่อประเภทนี้ถูกใช้แล้ว');
+            return FALSE;
+        }
+        return TRUE;
+    }
+}

--- a/application/models/Asset_model.php
+++ b/application/models/Asset_model.php
@@ -126,11 +126,9 @@ class Asset_model extends CI_Model {
      */
     public function get_asset_types()
     {
-        $this->db->distinct();
-        $this->db->select("asset_type");
-        $this->db->order_by("asset_type", "ASC");
-        $query = $this->db->get("assets");
-        return array_column($query->result_array(), "asset_type");
+        $this->db->order_by("type_name", "ASC");
+        $query = $this->db->get("asset_types");
+        return array_column($query->result_array(), "type_name");
     }
 
     /**

--- a/application/models/Assettype_model.php
+++ b/application/models/Assettype_model.php
@@ -1,0 +1,42 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Assettype_model extends CI_Model {
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->load->database();
+    }
+
+    public function get_all_types()
+    {
+        $this->db->order_by('type_name', 'ASC');
+        $query = $this->db->get('asset_types');
+        return $query->result_array();
+    }
+
+    public function get_type_by_id($id)
+    {
+        $this->db->where('type_id', $id);
+        $query = $this->db->get('asset_types');
+        return $query->row_array();
+    }
+
+    public function insert_type($data)
+    {
+        return $this->db->insert('asset_types', $data);
+    }
+
+    public function update_type($id, $data)
+    {
+        $this->db->where('type_id', $id);
+        return $this->db->update('asset_types', $data);
+    }
+
+    public function delete_type($id)
+    {
+        $this->db->where('type_id', $id);
+        return $this->db->delete('asset_types');
+    }
+}

--- a/application/views/assetmanager/add.php
+++ b/application/views/assetmanager/add.php
@@ -38,20 +38,18 @@
                     
                     <div class="col-md-4 mb-3">
                         <label for="asset_type" class="required">ประเภทครุภัณฑ์</label>
-                        <select class="form-control <?php echo form_error('asset_type') ? 'is-invalid' : ''; ?>" 
+                        <select class="form-control <?php echo form_error('asset_type') ? 'is-invalid' : ''; ?>"
                                 id="asset_type" name="asset_type" required>
                             <option value="">เลือกประเภท</option>
-                            <option value="คอมพิวเตอร์" <?php echo set_select('asset_type', 'คอมพิวเตอร์'); ?>>คอมพิวเตอร์</option>
-                            <option value="เครื่องพิมพ์" <?php echo set_select('asset_type', 'เครื่องพิมพ์'); ?>>เครื่องพิมพ์</option>
-                            <option value="เครื่องถ่ายเอกสาร" <?php echo set_select('asset_type', 'เครื่องถ่ายเอกสาร'); ?>>เครื่องถ่ายเอกสาร</option>
-                            <option value="โปรเจคเตอร์" <?php echo set_select('asset_type', 'โปรเจคเตอร์'); ?>>โปรเจคเตอร์</option>
-                            <option value="เครื่องปรับอากาศ" <?php echo set_select('asset_type', 'เครื่องปรับอากาศ'); ?>>เครื่องปรับอากาศ</option>
-                            <option value="รถยนต์" <?php echo set_select('asset_type', 'รถยนต์'); ?>>รถยนต์</option>
-                            <option value="เฟอร์นิเจอร์" <?php echo set_select('asset_type', 'เฟอร์นิเจอร์'); ?>>เฟอร์นิเจอร์</option>
-                            <option value="อุปกรณ์เครือข่าย" <?php echo set_select('asset_type', 'อุปกรณ์เครือข่าย'); ?>>อุปกรณ์เครือข่าย</option>
-                            <option value="อื่นๆ" <?php echo set_select('asset_type', 'อื่นๆ'); ?>>อื่นๆ</option>
+                            <?php if (!empty($asset_types)): ?>
+                                <?php foreach ($asset_types as $type): ?>
+                                    <option value="<?php echo htmlspecialchars($type); ?>" <?php echo set_select('asset_type', $type); ?>>
+                                        <?php echo htmlspecialchars($type); ?>
+                                    </option>
+                                <?php endforeach; ?>
+                            <?php endif; ?>
                         </select>
-                        <div class="invalid-feedback">
+                          <div class="invalid-feedback">
                             <?php echo form_error('asset_type'); ?>
                         </div>
                     </div>

--- a/application/views/assetmanager/edit.php
+++ b/application/views/assetmanager/edit.php
@@ -41,20 +41,18 @@
                     
                     <div class="col-md-4 mb-3">
                         <label for="asset_type" class="required">ประเภทครุภัณฑ์</label>
-                        <select class="form-control <?php echo form_error('asset_type') ? 'is-invalid' : ''; ?>" 
-                                id="asset_type" name="asset_type" required>
-                            <option value="">เลือกประเภท</option>
-                            <option value="คอมพิวเตอร์" <?php echo set_select('asset_type', 'คอมพิวเตอร์', $asset['asset_type'] == 'คอมพิวเตอร์'); ?>>คอมพิวเตอร์</option>
-                            <option value="เครื่องพิมพ์" <?php echo set_select('asset_type', 'เครื่องพิมพ์', $asset['asset_type'] == 'เครื่องพิมพ์'); ?>>เครื่องพิมพ์</option>
-                            <option value="เครื่องถ่ายเอกสาร" <?php echo set_select('asset_type', 'เครื่องถ่ายเอกสาร', $asset['asset_type'] == 'เครื่องถ่ายเอกสาร'); ?>>เครื่องถ่ายเอกสาร</option>
-                            <option value="โปรเจคเตอร์" <?php echo set_select('asset_type', 'โปรเจคเตอร์', $asset['asset_type'] == 'โปรเจคเตอร์'); ?>>โปรเจคเตอร์</option>
-                            <option value="เครื่องปรับอากาศ" <?php echo set_select('asset_type', 'เครื่องปรับอากาศ', $asset['asset_type'] == 'เครื่องปรับอากาศ'); ?>>เครื่องปรับอากาศ</option>
-                            <option value="รถยนต์" <?php echo set_select('asset_type', 'รถยนต์', $asset['asset_type'] == 'รถยนต์'); ?>>รถยนต์</option>
-                            <option value="เฟอร์นิเจอร์" <?php echo set_select('asset_type', 'เฟอร์นิเจอร์', $asset['asset_type'] == 'เฟอร์นิเจอร์'); ?>>เฟอร์นิเจอร์</option>
-                            <option value="อุปกรณ์เครือข่าย" <?php echo set_select('asset_type', 'อุปกรณ์เครือข่าย', $asset['asset_type'] == 'อุปกรณ์เครือข่าย'); ?>>อุปกรณ์เครือข่าย</option>
-                            <option value="อื่นๆ" <?php echo set_select('asset_type', 'อื่นๆ', $asset['asset_type'] == 'อื่นๆ'); ?>>อื่นๆ</option>
-                        </select>
-                        <div class="invalid-feedback">
+                          <select class="form-control <?php echo form_error('asset_type') ? 'is-invalid' : ''; ?>"
+                                  id="asset_type" name="asset_type" required>
+                              <option value="">เลือกประเภท</option>
+                              <?php if (!empty($asset_types)): ?>
+                                  <?php foreach ($asset_types as $type): ?>
+                                      <option value="<?php echo htmlspecialchars($type); ?>" <?php echo set_select('asset_type', $type, $asset['asset_type'] == $type); ?>>
+                                          <?php echo htmlspecialchars($type); ?>
+                                      </option>
+                                  <?php endforeach; ?>
+                              <?php endif; ?>
+                          </select>
+                          <div class="invalid-feedback">
                             <?php echo form_error('asset_type'); ?>
                         </div>
                     </div>

--- a/application/views/assettypes/add.php
+++ b/application/views/assettypes/add.php
@@ -1,0 +1,26 @@
+<div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+    <h1 class="h2">
+        <i class="fas fa-tag"></i>
+        เพิ่มประเภทครุภัณฑ์
+    </h1>
+</div>
+
+<div class="card">
+    <div class="card-body">
+        <?php echo form_open('assettypes/store'); ?>
+            <div class="form-group">
+                <label for="type_name" class="required">ชื่อประเภท</label>
+                <input type="text" class="form-control <?php echo form_error('type_name') ? 'is-invalid' : ''; ?>" name="type_name" value="<?php echo set_value('type_name'); ?>" required>
+                <div class="invalid-feedback">
+                    <?php echo form_error('type_name'); ?>
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="description">คำอธิบาย</label>
+                <textarea class="form-control" name="description" rows="3"><?php echo set_value('description'); ?></textarea>
+            </div>
+            <button type="submit" class="btn btn-primary">บันทึก</button>
+            <a href="<?php echo base_url('assettypes'); ?>" class="btn btn-secondary">ยกเลิก</a>
+        <?php echo form_close(); ?>
+    </div>
+</div>

--- a/application/views/assettypes/edit.php
+++ b/application/views/assettypes/edit.php
@@ -1,0 +1,26 @@
+<div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+    <h1 class="h2">
+        <i class="fas fa-edit"></i>
+        แก้ไขประเภทครุภัณฑ์
+    </h1>
+</div>
+
+<div class="card">
+    <div class="card-body">
+        <?php echo form_open('assettypes/update/' . $type['type_id']); ?>
+            <div class="form-group">
+                <label for="type_name" class="required">ชื่อประเภท</label>
+                <input type="text" class="form-control <?php echo form_error('type_name') ? 'is-invalid' : ''; ?>" name="type_name" value="<?php echo set_value('type_name', $type['type_name']); ?>" required>
+                <div class="invalid-feedback">
+                    <?php echo form_error('type_name'); ?>
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="description">คำอธิบาย</label>
+                <textarea class="form-control" name="description" rows="3"><?php echo set_value('description', $type['description']); ?></textarea>
+            </div>
+            <button type="submit" class="btn btn-primary">บันทึก</button>
+            <a href="<?php echo base_url('assettypes'); ?>" class="btn btn-secondary">ยกเลิก</a>
+        <?php echo form_close(); ?>
+    </div>
+</div>

--- a/application/views/assettypes/index.php
+++ b/application/views/assettypes/index.php
@@ -1,0 +1,47 @@
+<div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+    <h1 class="h2">
+        <i class="fas fa-tags"></i>
+        ประเภทครุภัณฑ์
+    </h1>
+    <div class="btn-toolbar mb-2 mb-md-0">
+        <a href="<?php echo base_url('assettypes/add'); ?>" class="btn btn-primary">
+            <i class="fas fa-plus"></i> เพิ่มประเภท
+        </a>
+    </div>
+</div>
+
+<div class="card">
+    <div class="card-body">
+        <?php if (!empty($types)): ?>
+            <div class="table-responsive">
+                <table class="table table-striped">
+                    <thead>
+                        <tr>
+                            <th>ชื่อประเภท</th>
+                            <th>คำอธิบาย</th>
+                            <th>การดำเนินการ</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($types as $type): ?>
+                            <tr>
+                                <td><?php echo htmlspecialchars($type['type_name']); ?></td>
+                                <td><?php echo htmlspecialchars($type['description']); ?></td>
+                                <td>
+                                    <a href="<?php echo base_url('assettypes/edit/' . $type['type_id']); ?>" class="btn btn-sm btn-warning">
+                                        <i class="fas fa-edit"></i>
+                                    </a>
+                                    <a href="<?php echo base_url('assettypes/delete/' . $type['type_id']); ?>" class="btn btn-sm btn-danger" onclick="return confirm('คุณแน่ใจหรือไม่ที่จะลบประเภทนี้?');">
+                                        <i class="fas fa-trash-alt"></i>
+                                    </a>
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+            </div>
+        <?php else: ?>
+            <p class="text-center text-muted mb-0">ไม่พบประเภทครุภัณฑ์</p>
+        <?php endif; ?>
+    </div>
+</div>

--- a/application/views/templates/header.php
+++ b/application/views/templates/header.php
@@ -49,6 +49,14 @@
                                 จัดการครุภัณฑ์
                             </a>
                         </li>
+                        <li class="nav-item">
+                            <a class="nav-link <?php echo (isset($page_name) && strpos($page_name, 'assettypes') !== false) ? 'active' : ''; ?>"
+                               href="<?php echo base_url('assettypes'); ?>">
+                                <i class="fas fa-tags"></i>
+                                ประเภทครุภัณฑ์
+                            </a>
+                        </li>
+
                         
                         <li class="nav-item">
                             <a class="nav-link <?php echo (isset($page_name) && strpos($page_name, 'transfer') !== false) ? 'active' : ''; ?>" 

--- a/asset_management_use.sql
+++ b/asset_management_use.sql
@@ -55,6 +55,30 @@ INSERT INTO `annual_surveys` (`survey_id`, `survey_year`, `asset_id`, `condition
 -- --------------------------------------------------------
 
 --
+--
+-- Table structure for table `asset_types`
+--
+CREATE TABLE `asset_types` (
+  `type_id` int(11) NOT NULL,
+  `type_name` varchar(100) NOT NULL,
+  `description` text
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='ตารางประเภทครุภัณฑ์';
+
+--
+-- Dumping data for table `asset_types`
+--
+INSERT INTO `asset_types` (`type_id`, `type_name`, `description`) VALUES
+(1, 'คอมพิวเตอร์', NULL),
+(2, 'เครื่องพิมพ์', NULL),
+(3, 'เครื่องถ่ายเอกสาร', NULL),
+(4, 'โปรเจคเตอร์', NULL),
+(5, 'เครื่องปรับอากาศ', NULL),
+(6, 'รถยนต์', NULL),
+(7, 'เฟอร์นิเจอร์', NULL),
+(8, 'อุปกรณ์เครือข่าย', NULL);
+
+-- --------------------------------------------------------
+
 -- Table structure for table `assets`
 --
 
@@ -287,6 +311,12 @@ INSERT INTO `users` (`user_id`, `username`, `password`, `full_name`, `email`, `r
 --
 
 --
+-- Indexes for table `asset_types`
+--
+ALTER TABLE `asset_types`
+  ADD PRIMARY KEY (`type_id`),
+  ADD UNIQUE KEY `type_name` (`type_name`);
+
 -- Indexes for table `annual_surveys`
 --
 ALTER TABLE `annual_surveys`
@@ -380,6 +410,10 @@ ALTER TABLE `users`
 --
 
 --
+-- AUTO_INCREMENT for table `asset_types`
+ALTER TABLE `asset_types`
+  MODIFY `type_id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=9;
+
 -- AUTO_INCREMENT for table `annual_surveys`
 --
 ALTER TABLE `annual_surveys`

--- a/database.sql
+++ b/database.sql
@@ -4,6 +4,25 @@
 CREATE DATABASE IF NOT EXISTS `asset_management` DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci;
 USE `asset_management`;
 
+-- ตาราง: asset_types (ประเภทครุภัณฑ์)
+CREATE TABLE `asset_types` (
+  `type_id` int(11) NOT NULL AUTO_INCREMENT,
+  `type_name` varchar(100) NOT NULL UNIQUE COMMENT 'ชื่อประเภทครุภัณฑ์',
+  `description` text DEFAULT NULL COMMENT 'คำอธิบาย',
+  PRIMARY KEY (`type_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='ตารางประเภทครุภัณฑ์';
+
+-- ข้อมูลเริ่มต้นสำหรับประเภทครุภัณฑ์
+INSERT INTO `asset_types` (`type_name`, `description`) VALUES
+('คอมพิวเตอร์', NULL),
+('เครื่องพิมพ์', NULL),
+('เครื่องถ่ายเอกสาร', NULL),
+('โปรเจคเตอร์', NULL),
+('เครื่องปรับอากาศ', NULL),
+('รถยนต์', NULL),
+('เฟอร์นิเจอร์', NULL),
+('อุปกรณ์เครือข่าย', NULL);
+
 -- ตาราง: assets (ครุภัณฑ์)
 CREATE TABLE `assets` (
   `asset_id` int(11) NOT NULL AUTO_INCREMENT,


### PR DESCRIPTION
## Summary
- add Assettypes controller, model, and views for managing asset categories
- allow asset forms to pull types dynamically from new `asset_types` table
- update navigation, routes, and database schema for category management

## Testing
- `php -l application/models/Assettype_model.php`
- `php -l application/controllers/Assettypes.php`
- `php -l application/views/assettypes/index.php`
- `php -l application/views/assettypes/add.php`
- `php -l application/views/assettypes/edit.php`
- `php -l application/views/templates/header.php`
- `php -l application/controllers/Assetmanager.php`
- `php -l application/models/Asset_model.php`
- `php -l application/views/assetmanager/add.php`
- `php -l application/views/assetmanager/edit.php`
- `php -l application/config/routes.php`
- `php test_system.php` *(fails: Failed opening required '1core/CodeIgniter.php')*

------
https://chatgpt.com/codex/tasks/task_e_689d4e489a7c8328af6d1c74416512ce