### PR TITLE
Handle missing guarantee creation date

### DIFF
--- a/application/views/guarantees/view.php
+++ b/application/views/guarantees/view.php
@@ -155,7 +155,13 @@ $is_expiring_soon = $days_remaining <= 30 && $days_remaining >= 0;
                             </tr>
                             <tr>
                                 <td class="font-weight-bold">วันที่บันทึก:</td>
-                                <td><?php echo date('d/m/Y H:i', strtotime($guarantee['created_date'])); ?></td>
+                                <td>
+                                    <?php if (!empty($guarantee['created_date'])): ?>
+                                        <?php echo date('d/m/Y H:i', strtotime($guarantee['created_date'])); ?>
+                                    <?php else: ?>
+                                        N/A
+                                    <?php endif; ?>
+                                </td>
                             </tr>
                             <?php if (!empty($guarantee['updated_date'])): ?>
                             <tr>


### PR DESCRIPTION
## Summary
- Avoid PHP notice by checking for missing guarantee creation date before formatting

## Testing
- `php -l application/views/guarantees/view.php`
- `php test_system.php` *(fails: Failed opening required '1core/CodeIgniter.php')*


------
https://chatgpt.com/codex/tasks/task_e_689d5b5f089c83288d982701db5f2100