### PR TITLE
Fix undefined purchase date in guarantee view

### DIFF
--- a/application/models/Guarantee_model.php
+++ b/application/models/Guarantee_model.php
@@ -30,7 +30,8 @@ class Guarantee_model extends CI_Model {
     public function get_guarantee_by_id($guarantee_id)
     {
         // Join กับตาราง assets เพื่อดึงข้อมูลครุภัณฑ์ที่เกี่ยวข้อง
-        $this->db->select('g.*, a.asset_name, a.serial_number AS asset_code, a.asset_type AS category, a.current_location');
+        // เพิ่มฟิลด์วันที่จัดซื้อและราคาทุนของครุภัณฑ์ เพื่อใช้แสดงผลในหน้า view
+        $this->db->select('g.*, a.asset_name, a.serial_number AS asset_code, a.asset_type AS category, a.current_location, a.purchase_date, a.purchase_price');
         $this->db->from('contract_guarantees g');
         $this->db->join('assets a', 'a.asset_id = g.asset_id', 'left');
         $this->db->where('g.guarantee_id', $guarantee_id);

--- a/application/views/guarantees/view.php
+++ b/application/views/guarantees/view.php
@@ -218,11 +218,23 @@ $is_expiring_soon = $days_remaining <= 30 && $days_remaining >= 0;
                             </tr>
                             <tr>
                                 <td class="font-weight-bold">วันที่จัดซื้อ:</td>
-                                <td><?php echo date('d/m/Y', strtotime($guarantee['purchase_date'])); ?></td>
+                                <td>
+                                    <?php if (!empty($guarantee['purchase_date'])): ?>
+                                        <?php echo date('d/m/Y', strtotime($guarantee['purchase_date'])); ?>
+                                    <?php else: ?>
+                                        <span class="text-muted">-</span>
+                                    <?php endif; ?>
+                                </td>
                             </tr>
                             <tr>
                                 <td class="font-weight-bold">ราคาทุน:</td>
-                                <td><?php echo number_format($guarantee['purchase_price'], 2); ?> บาท</td>
+                                <td>
+                                    <?php if (isset($guarantee['purchase_price'])): ?>
+                                        <?php echo number_format($guarantee['purchase_price'], 2); ?> บาท
+                                    <?php else: ?>
+                                        <span class="text-muted">-</span>
+                                    <?php endif; ?>
+                                </td>
                             </tr>
                         </table>
                     </div>


### PR DESCRIPTION
## Summary
- Fetch asset purchase date and price when loading guarantee details
- Show purchase info in guarantee view only when available

## Testing
- `php -l application/models/Guarantee_model.php`
- `php -l application/views/guarantees/view.php`
- `composer install --no-interaction` *(fails: CONNECT tunnel failed, response 403)*
- `phpunit` *(command not found)*
- `php test_system.php` *(failed: Failed opening required '1core/CodeIgniter.php')*

------
https://chatgpt.com/codex/tasks/task_e_689d5db22cd08328a104c28f67685ef7