### PR TITLE
Handle missing vendor contact in edit view

### DIFF
--- a/application/views/guarantees/edit.php
+++ b/application/views/guarantees/edit.php
@@ -105,8 +105,8 @@
                         </div>
                         <div class="col-md-6 mb-3">
                             <label for="vendor_contact" class="required">ข้อมูลติดต่อ</label>
-                            <input type="text" class="form-control" id="vendor_contact" name="vendor_contact" 
-                                   value="<?php echo set_value("vendor_contact", $guarantee["vendor_contact"]); ?>" required
+                            <input type="text" class="form-control" id="vendor_contact" name="vendor_contact"
+                                   value="<?php echo set_value("vendor_contact", isset($guarantee["vendor_contact"]) ? $guarantee["vendor_contact"] : ""); ?>" required
                                    placeholder="เบอร์โทร, อีเมล, หรือที่อยู่">
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- Avoid PHP notice in guarantee edit view when `vendor_contact` is missing

## Testing
- `php -l application/views/guarantees/edit.php`
- `php test_system.php` *(fails: Failed opening required '1core/CodeIgniter.php')*

------
https://chatgpt.com/codex/tasks/task_e_689d613106bc8328b70bcd093f766fb1