### PR TITLE
Fix undefined variable in repair edit form

### DIFF
--- a/application/controllers/Repairs.php
+++ b/application/controllers/Repairs.php
@@ -165,13 +165,16 @@ class Repairs extends CI_Controller {
         $data = array();
         
         $data['repair'] = $this->Repair_model->get_repair_by_id($repair_id);
-        
+
         if (!$data['repair']) {
             show_404();
         }
-        
+
         // ดึงรายการครุภัณฑ์ที่สามารถซ่อมแซมได้
         $data['assets'] = $this->Asset_model->get_repairable_assets();
+
+        // กำหนดครุภัณฑ์ที่ถูกเลือกไว้เดิมเพื่อใช้ในฟอร์มแก้ไข
+        $data['selected_asset_id'] = $data['repair']['asset_id'];
         
         $data['page_title'] = 'แก้ไขการซ่อมแซม #' . $repair_id;
         $data['page_name'] = 'edit_repair';


### PR DESCRIPTION
## Summary
- Pass selected asset ID to the repair edit view to prevent undefined variable notices

## Testing
- `php -l application/controllers/Repairs.php`
- `php -l application/views/repairs/edit.php`


------
https://chatgpt.com/codex/tasks/task_e_689d8c62f68883288d60cdc34f504f60