### PR TITLE
Add vendor contact fields to contract guarantees schema

### DIFF
--- a/application/models/Guarantee_model.php
+++ b/application/models/Guarantee_model.php
@@ -14,7 +14,7 @@ class Guarantee_model extends CI_Model {
      */
     public function get_all_guarantees($limit = null, $offset = null)
     {
-        $this->db->order_by('created_at', 'DESC');
+        $this->db->order_by('created_date', 'DESC');
         
         if ($limit !== null) {
             $this->db->limit($limit, $offset);
@@ -283,7 +283,7 @@ public function search_guarantees($keyword = null, $status = null, $vendor = nul
     {
         $data = array(
             'status' => 'หมดอายุ',
-            'updated_at' => date('Y-m-d H:i:s')
+            'updated_date' => date('Y-m-d H:i:s')
         );
         
         $this->db->where('end_date <', date('Y-m-d'));
@@ -404,7 +404,7 @@ public function search_guarantees($keyword = null, $status = null, $vendor = nul
      */
     public function get_recent_guarantees($limit = 10)
     {
-        $this->db->order_by('created_at', 'DESC');
+        $this->db->order_by('created_date', 'DESC');
         $this->db->limit($limit);
         $query = $this->db->get('contract_guarantees');
         return $query->result_array();

--- a/database.sql
+++ b/database.sql
@@ -122,25 +122,29 @@ CREATE TABLE `contract_guarantees` (
   `guarantee_id` int(11) NOT NULL,
   `asset_id` int(11) DEFAULT NULL,
   `vendor_name` varchar(255) NOT NULL,
+  `vendor_contact` varchar(255) DEFAULT NULL,
   `contract_number` varchar(100) NOT NULL COMMENT 'เลขที่สัญญา',
   `guarantee_type` varchar(100) NOT NULL COMMENT 'ประเภทการค้ำประกัน',
   `guarantee_amount` decimal(15,2) NOT NULL COMMENT 'จำนวนเงินค้ำประกัน',
   `start_date` date NOT NULL COMMENT 'วันที่เริ่มต้น',
   `end_date` date NOT NULL COMMENT 'วันที่สิ้นสุด',
-  `guarantee_provider` varchar(255) NOT NULL COMMENT 'ผู้ค้ำประกัน',
+  `guarantee_provider` varchar(255) DEFAULT NULL COMMENT 'ผู้ค้ำประกัน',
+  `coverage_details` text COMMENT 'รายละเอียดความคุ้มครอง',
+  `terms_conditions` text COMMENT 'เงื่อนไขและข้อกำหนด',
+  `claim_procedure` text COMMENT 'ขั้นตอนการเคลม',
   `notes` text COMMENT 'บันทึกเพิ่มเติม',
   `status` enum('ใช้งาน','หมดอายุ','ยกเลิก') NOT NULL DEFAULT 'ใช้งาน' COMMENT 'สถานะ',
-  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+  `created_date` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_date` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='ตารางค้ำประกันสัญญา';
 
 --
 -- Dumping data for table `contract_guarantees`
 --
 
-INSERT INTO `contract_guarantees` (`guarantee_id`, `asset_id`, `vendor_name`, `contract_number`, `guarantee_type`, `guarantee_amount`, `start_date`, `end_date`, `guarantee_provider`, `notes`, `status`, `created_at`) VALUES
-(1, NULL, '', 'CON2024001', 'หนังสือค้ำประกัน', '50000.00', '2024-01-01', '2024-12-31', 'ธนาคารกรุงเทพ', NULL, 'ใช้งาน', '2025-08-06 03:33:18'),
-(2, NULL, '', 'CON2024002', 'เงินสดค้ำประกัน', '25000.00', '2024-02-01', '2025-01-31', 'บริษัท ABC จำกัด', NULL, 'ใช้งาน', '2025-08-06 03:33:18');
+INSERT INTO `contract_guarantees` (`guarantee_id`, `asset_id`, `vendor_name`, `vendor_contact`, `contract_number`, `guarantee_type`, `guarantee_amount`, `start_date`, `end_date`, `guarantee_provider`, `coverage_details`, `terms_conditions`, `claim_procedure`, `notes`, `status`, `created_date`) VALUES
+(1, NULL, '', '', 'CON2024001', 'หนังสือค้ำประกัน', '50000.00', '2024-01-01', '2024-12-31', 'ธนาคารกรุงเทพ', NULL, NULL, NULL, NULL, 'ใช้งาน', '2025-08-06 03:33:18'),
+(2, NULL, '', '', 'CON2024002', 'เงินสดค้ำประกัน', '25000.00', '2024-02-01', '2025-01-31', 'บริษัท ABC จำกัด', NULL, NULL, NULL, NULL, 'ใช้งาน', '2025-08-06 03:33:18');
 
 -- --------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Expand contract_guarantees table with vendor contact and coverage details fields and switch to created_date/updated_date timestamps
- Align Guarantee_model with new schema using created_date and updated_date

## Testing
- `php -l application/models/Guarantee_model.php`


------
https://chatgpt.com/codex/tasks/task_e_689d8f68f7788328972c55972ac0a562